### PR TITLE
Add the ability to specify an address to ouro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ouro"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouro"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 [dependencies]

--- a/flake.nix
+++ b/flake.nix
@@ -179,7 +179,7 @@
         packages = {
           default = pkgs.rustPlatform.buildRustPackage {
             pname = "ouro";
-            version = "0.1.4";
+            version = "0.1.5";
 
             src = lib.fileset.toSource {
               root = ./.;

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
                                   type = types.str;
                                   default = "127.0.0.1:9091";
                                   description = ''
-                                    The address and port oura will provide transmission remote for
+                                    The address and port ouro will provide transmission remote for
                                     it to connect to. Can be <IP>:<Port> or just <IP>.
                                   '';
                                 };

--- a/flake.nix
+++ b/flake.nix
@@ -84,8 +84,8 @@
                                   type = types.str;
                                   default = "127.0.0.1:9091";
                                   description = ''
-                                    The address and port ouro will provide transmission remote for
-                                    it to connect to. Can be <IP>:<Port> or just <IP>.
+                                    The address and port that ouro will provide to `transmission-remote`
+                                    for it to connect to. Can be <IP>:<Port> or just <IP>.
                                   '';
                                 };
                               };

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,14 @@
                                 RPC_PASS = lib.mkOption {
                                   type = types.str;
                                 };
+                                ADDRESS = lib.mkOption {
+                                  type = types.str;
+                                  default = "127.0.0.1:9091";
+                                  description = ''
+                                    The address and port oura will provide transmission remote for
+                                    it to connect to. Can be <IP>:<Port> or just <IP>.
+                                  '';
+                                };
                               };
                             };
                           };
@@ -130,7 +138,7 @@
                       ouroArgs = if ouroConfig.slskd.enable then
                         "slskd"
                       else if ouroConfig.transmission.enable then
-                        "transmission --rpc-user ${ouroConfig.transmission.RPC_USER} --rpc-pass ${ouroConfig.transmission.RPC_PASS}"
+                        "transmission --rpc-user ${ouroConfig.transmission.RPC_USER} --rpc-pass ${ouroConfig.transmission.RPC_PASS} --address ${ouroConfig.transmission.ADDRESS}"
                       else
                         throw "Either `slskd` or `transmission` need to be enabled!";
                     in {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ pub struct TransmissionArgs {
     /// Transmission RPC password
     #[arg(long)]
     pub rpc_pass: Option<String>,
+
+    /// Transmission address
+    #[arg(long)]
+    pub address: Option<String>,
 }
 
 #[tokio::main]
@@ -54,6 +58,7 @@ async fn main() -> eyre::Result<()> {
         ServiceType::Transmission(TransmissionArgs {
             ref rpc_user,
             ref rpc_pass,
+            ref address,
         }) => {
             let rpc_credentials = match (rpc_user, rpc_pass) {
                 (Some(username), Some(password)) => Some(Credentials {
@@ -62,8 +67,14 @@ async fn main() -> eyre::Result<()> {
                 }),
                 _ => None,
             };
+
+            if let Some(addr) = address {
+                info!("Using {} for transmission", addr);
+            }
+
             ServiceData::Transmission(Transmission {
                 rpc_credentials,
+                address: address.clone(),
                 current_ports: Ports { udp: 0, tcp: 0 },
             })
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -224,7 +224,7 @@ impl Service for Transmission {
     async fn update(&self, ports: &Ports) -> eyre::Result<()> {
         let mut cmd = Command::new("transmission-remote");
         if let Some(addr) = &self.address {
-            cmd.args([addr]);
+            cmd.arg(addr);
         }
 
         // TODO: leaked in `ps`, pass through STDIN

--- a/src/service.rs
+++ b/src/service.rs
@@ -202,6 +202,7 @@ impl Service for Slskd {
 #[derive(Debug, Clone)]
 pub struct Transmission {
     pub rpc_credentials: Option<Credentials>,
+    pub address: Option<String>,
     pub current_ports: Ports,
 }
 
@@ -222,6 +223,10 @@ impl Service for Transmission {
 
     async fn update(&self, ports: &Ports) -> eyre::Result<()> {
         let mut cmd = Command::new("transmission-remote");
+        if let Some(addr) = &self.address {
+            cmd.args([addr]);
+        }
+
         // TODO: leaked in `ps`, pass through STDIN
         self.rpc_credentials
             .as_ref()

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,7 @@ use tokio::{fs, process::Command, sync::broadcast};
 use tracing::{debug, error, info};
 
 use crate::{
-    Cli,
+    GlobalArgs,
     firewall::manage_firewall,
     port_manager::{Ports, map_ports},
 };
@@ -50,7 +50,11 @@ pub(crate) trait Service {
         Ok(())
     }
 
-    async fn run(&mut self, args: &Cli, mut shutdown: broadcast::Receiver<()>) -> eyre::Result<()> {
+    async fn run(
+        &mut self,
+        args: &GlobalArgs,
+        mut shutdown: broadcast::Receiver<()>,
+    ) -> eyre::Result<()> {
         let client = natpmp::new_tokio_natpmp_with(args.gateway).await?;
         let mut interval = tokio::time::interval(Duration::from_secs(45));
 
@@ -143,7 +147,11 @@ impl Service for ServiceData {
         }
     }
 
-    async fn run(&mut self, args: &Cli, shutdown: broadcast::Receiver<()>) -> eyre::Result<()> {
+    async fn run(
+        &mut self,
+        args: &GlobalArgs,
+        shutdown: broadcast::Receiver<()>,
+    ) -> eyre::Result<()> {
         match self {
             ServiceData::Slskd(slskd) => slskd.run(args, shutdown).await,
             ServiceData::Transmission(transmission) => transmission.run(args, shutdown).await,


### PR DESCRIPTION
## Problem
When using ouro with transmission, the connection to transmission was failing due to the localhost not being able to access transmission. There was no mechanism that I knew of that could resolve this (It's possible I messed up my configuration on nix which resulted in this issue).

## Solution
- Add a new arg called ``address`` when running as transmission (optional)
- If arg ``address`` is supplied with transmission, provide the argument to transmission-remote
- Add the ADDRESS argument to the flake.nix file to allow it to be passed to ouro
- Add a print message to alert the user what address will be used, if one is supplied.

## Testing
- [x] Added ADDRESS with the expected ip to my nix flake and confirmed transmission successfully updated the value.

## Note
There appears to be a bug that when updating the port, if the call to transmission fails, the new port will get set to the current port, even though transmission never actually applied it. Resulting in ouro desyncing the actual port set with transmission. 